### PR TITLE
Cleaner way to wrap native objects

### DIFF
--- a/kicad/obj.py
+++ b/kicad/obj.py
@@ -1,0 +1,34 @@
+#  Copyright 2015 Miguel Angel Ajo Pelayo <miguelangel@ajo.es>
+#
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 2 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program; if not, write to the Free Software
+#  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+#  MA 02110-1301, USA.
+#
+
+
+class BareClass(object):
+    pass
+
+
+def new(class_type):
+    """Returns an object of class without calling __init__.
+
+    This could lead to inconsistent objects, use only when you
+    know what you're doing.
+    In kicad-python this is used to construct wrapper classes
+    before injecting the native object.
+    """
+    obj = BareClass()
+    obj.__class__ = class_type
+    return obj

--- a/tests/unit/pcbnew/test_pcbnew_drawing.py
+++ b/tests/unit/pcbnew/test_pcbnew_drawing.py
@@ -1,0 +1,11 @@
+import unittest
+
+from kicad import *
+from kicad.pcbnew.drawing import *
+
+
+class TestPcbnewDrawing(unittest.TestCase):
+    def test_segment_from_native(self):
+        native_segment = Segment((0, 0), (1, 1)).native_obj
+        new_segment = Segment.from_native(native_segment)
+        self.assertEqual(Segment, type(new_segment))

--- a/tox.ini
+++ b/tox.ini
@@ -27,11 +27,12 @@ commands = {posargs}
 # E128 continuation line under-indented for visual indent
 # E129 visually indented line with same indent as next logical line
 # E265 block comment should start with ‘# ‘
+# E402 module level import not at top of file
 # H305 imports not grouped correctly
 # H404 multi line docstring should start with a summary
 # H405 multi line docstring summary not separated with an empty line
 # F403 import *, we use it to populate main modeles
-ignore = E125,E126,E128,E129,E265,H305,H404,H405,F403
+ignore = E125,E126,E128,E129,E265,H305,H404,H405,F403,E402
 show-source = true
 builtins = _
 exclude = .venv,.git,.tox,dist,doc,*lib/python*,*egg,build,tools,.opeproject,kicad/pcbnew/pcbnew_easy.py


### PR DESCRIPTION
This should be implemented for Board, and all other classes,
instead of using default parameters with None, which can
become very unnatural/tricky.
