### PR TITLE
General obj.wrap command for easy generic wrapping.

### DIFF
--- a/kicad/__init__.py
+++ b/kicad/__init__.py
@@ -19,3 +19,21 @@
 from .units import *
 from .point import *
 from .size import *
+
+
+class BareClass(object):
+    pass
+
+
+def new(class_type, instance):
+    """Returns an object of class without calling __init__.
+
+    This could lead to inconsistent objects, use only when you
+    know what you're doing.
+    In kicad-python this is used to construct wrapper classes
+    before injecting the native object.
+    """
+    obj = BareClass()
+    obj.__class__ = class_type
+    obj._obj = instance
+    return obj

--- a/kicad/obj.py
+++ b/kicad/obj.py
@@ -15,20 +15,17 @@
 #  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
 #  MA 02110-1301, USA.
 #
+pcbnew = __import__('pcbnew')
+from kicad.pcbnew import drawing as pcbnew_drawing
 
 
-class BareClass(object):
-    pass
+_WRAPPERS = [(pcbnew_drawing.WRAPPED_CLASSES, pcbnew_drawing.wrap)]
 
 
-def new(class_type):
-    """Returns an object of class without calling __init__.
+def wrap(instance):
+    """Returns a python wrapped object from a swig/C++ one."""
+    for classes, wrapper in _WRAPPERS:
+        if type(instance) in classes:
+            return wrapper(instance)
 
-    This could lead to inconsistent objects, use only when you
-    know what you're doing.
-    In kicad-python this is used to construct wrapper classes
-    before injecting the native object.
-    """
-    obj = BareClass()
-    obj.__class__ = class_type
-    return obj
+    raise ValueError("Class with no wrapper: %s" % type(instance))

--- a/tests/unit/pcbnew/test_pcbnew_drawing.py
+++ b/tests/unit/pcbnew/test_pcbnew_drawing.py
@@ -2,10 +2,21 @@ import unittest
 
 from kicad import *
 from kicad.pcbnew.drawing import *
+from kicad import obj
 
 
 class TestPcbnewDrawing(unittest.TestCase):
     def test_segment_from_native(self):
-        native_segment = Segment((0, 0), (1, 1)).native_obj
-        new_segment = Segment.from_native(native_segment)
+        native_segment = Segment((0, 0), (1, 1))._obj
+        new_segment = obj.wrap(native_segment)
         self.assertEqual(Segment, type(new_segment))
+
+    def test_circle_from_native(self):
+        native_circle = Circle((0, 0), 10.0)._obj
+        new_circle = obj.wrap(native_circle)
+        self.assertEqual(Circle, type(new_circle))
+
+    def test_arc_from_native(self):
+        native_arc = Arc((0, 0), 10.0, -90, 90)._obj
+        new_arc = obj.wrap(native_arc)
+        self.assertEqual(Arc, type(new_arc))


### PR DESCRIPTION
The wrap command should be able to detect the target
C++ class and call the specific wrapper.

The "new" method has been moved to kicad/**init**.py
to avoid circular dependencies.
